### PR TITLE
Adds TlsHelper from Azure-Pipelines-Tasks to fix TLS 1.2 issues

### DIFF
--- a/Pre-Build.ps1
+++ b/Pre-Build.ps1
@@ -1,13 +1,13 @@
-Copy-Item tf-vc-shared\v1\* tf-vc-delete\v1 -force -recurse -exclude *.*proj
-Copy-Item tf-vc-shared\v1\* tf-vc-add\v1 -force -recurse -exclude *.*proj
-Copy-Item tf-vc-shared\v1\* tf-vc-undo\v1 -force -recurse -exclude *.*proj
-Copy-Item tf-vc-shared\v1\* tf-vc-checkin\v1 -force -recurse -exclude *.*proj
-Copy-Item tf-vc-shared\v1\* tf-vc-checkout\v1 -force -recurse -exclude *.*proj
-Copy-Item tf-vc-shared\v1\* tf-vc-shelveset-update\v1 -force -recurse -exclude *.*proj
+Copy-Item $PSScriptRoot\tf-vc-shared\v1\* $PSScriptRoot\tf-vc-delete\v1 -force -recurse -exclude *.*proj
+Copy-Item $PSScriptRoot\tf-vc-shared\v1\* $PSScriptRoot\tf-vc-add\v1 -force -recurse -exclude *.*proj
+Copy-Item $PSScriptRoot\tf-vc-shared\v1\* $PSScriptRoot\tf-vc-undo\v1 -force -recurse -exclude *.*proj
+Copy-Item $PSScriptRoot\tf-vc-shared\v1\* $PSScriptRoot\tf-vc-checkin\v1 -force -recurse -exclude *.*proj
+Copy-Item $PSScriptRoot\tf-vc-shared\v1\* $PSScriptRoot\tf-vc-checkout\v1 -force -recurse -exclude *.*proj
+Copy-Item $PSScriptRoot\tf-vc-shared\v1\* $PSScriptRoot\tf-vc-shelveset-update\v1 -force -recurse -exclude *.*proj
 
-Copy-Item tf-vc-shared\v2\* tf-vc-delete\v2 -force -recurse -exclude *.*proj
-Copy-Item tf-vc-shared\v2\* tf-vc-add\v2 -force -recurse -exclude *.*proj
-Copy-Item tf-vc-shared\v2\* tf-vc-undo\v2 -force -recurse -exclude *.*proj
-Copy-Item tf-vc-shared\v2\* tf-vc-checkin\v2 -force -recurse -exclude *.*proj
-Copy-Item tf-vc-shared\v2\* tf-vc-checkout\v2 -force -recurse -exclude *.*proj
-Copy-Item tf-vc-shared\v2\* tf-vc-shelveset-update\v2 -force -recurse -exclude *.*proj
+Copy-Item $PSScriptRoot\tf-vc-shared\v2\* $PSScriptRoot\tf-vc-delete\v2 -force -recurse -exclude *.*proj
+Copy-Item $PSScriptRoot\tf-vc-shared\v2\* $PSScriptRoot\tf-vc-add\v2 -force -recurse -exclude *.*proj
+Copy-Item $PSScriptRoot\tf-vc-shared\v2\* $PSScriptRoot\tf-vc-undo\v2 -force -recurse -exclude *.*proj
+Copy-Item $PSScriptRoot\tf-vc-shared\v2\* $PSScriptRoot\tf-vc-checkin\v2 -force -recurse -exclude *.*proj
+Copy-Item $PSScriptRoot\tf-vc-shared\v2\* $PSScriptRoot\tf-vc-checkout\v2 -force -recurse -exclude *.*proj
+Copy-Item $PSScriptRoot\tf-vc-shared\v2\* $PSScriptRoot\tf-vc-shelveset-update\v2 -force -recurse -exclude *.*proj

--- a/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/de-de/resources.resjson
+++ b/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/de-de/resources.resjson
@@ -1,0 +1,5 @@
+{
+  "loc.messages.UnsupportedTLSError": "Stellen Sie sicher, dass der Computer das TLS 1.2-Protokoll oder eine höhere Version verwendet. Weitere Informationen zum Aktivieren von TLS auf Ihrem Computer finden Sie unter https://aka.ms/enableTlsv2.",
+  "loc.messages.TLS12AddedInSession": "TLS 1.2 wurde in der Sitzung hinzugefügt.",
+  "loc.messages.UnableToAddTls12InSession": "Fehler beim Hinzufügen von TLS 1.2 in der aktuellen Sitzung. Fehler: {0}"
+}

--- a/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/en-US/resources.resjson
+++ b/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/en-US/resources.resjson
@@ -1,0 +1,5 @@
+{
+  "loc.messages.UnsupportedTLSError": "Make sure the machine is using TLS 1.2 protocol or higher. Check https://aka.ms/enableTlsv2 for more information on how to enable TLS in your machine.",
+  "loc.messages.TLS12AddedInSession": "Added TLS 1.2 in session.",
+  "loc.messages.UnableToAddTls12InSession": "Failed to add TLS 1.2 in current session. Error: '{0}'"
+}

--- a/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/es-es/resources.resjson
+++ b/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/es-es/resources.resjson
@@ -1,0 +1,5 @@
+{
+  "loc.messages.UnsupportedTLSError": "Asegúrese de que el equipo usa el protocolo TLS 1.2 o posterior. Consulte https://aka.ms/enableTlsv2 para obtener más información sobre cómo habilitar TLS en la máquina.",
+  "loc.messages.TLS12AddedInSession": "Se agregó TLS 1.2 en la sesión.",
+  "loc.messages.UnableToAddTls12InSession": "No se pudo agregar TLS 1.2 en la sesión actual. Error: \"{0}\""
+}

--- a/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/fr-fr/resources.resjson
@@ -1,0 +1,5 @@
+{
+  "loc.messages.UnsupportedTLSError": "Assurez-vous que l'ordinateur utilise le protocole TLS 1.2 ou ultérieur. Consultez https://aka.ms/enableTlsv2 pour plus d'informations sur l'activation de TLS sur votre ordinateur.",
+  "loc.messages.TLS12AddedInSession": "Ajout du protocole TLS 1.2 à la session.",
+  "loc.messages.UnableToAddTls12InSession": "Échec de l'ajout du protocole TLS 1.2 à la session active. Erreur : '{0}'"
+}

--- a/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/it-IT/resources.resjson
+++ b/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/it-IT/resources.resjson
@@ -1,0 +1,5 @@
+{
+  "loc.messages.UnsupportedTLSError": "Assicurarsi che il computer usi il protocollo TLS 1.2 o superiore. Per altre informazioni su come abilitare TLS nel computer, vedere https://aka.ms/enableTlsv2.",
+  "loc.messages.TLS12AddedInSession": "TLS 1.2 è stato aggiunto nella sessione.",
+  "loc.messages.UnableToAddTls12InSession": "Non è stato possibile aggiungere TLS 1.2 nella sessione corrente. Errore: '{0}'"
+}

--- a/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/ja-jp/resources.resjson
@@ -1,0 +1,5 @@
+{
+  "loc.messages.UnsupportedTLSError": "マシンで TLS 1.2 プロトコル以上を使用していることを確認します。お使いのマシンで TLS を有効にする方法について詳しくは、https://aka.ms/enableTlsv2 をご確認ください。",
+  "loc.messages.TLS12AddedInSession": "セッションで TLS 1.2 を追加しました。",
+  "loc.messages.UnableToAddTls12InSession": "現在のセッションで TLS 1.2 を追加できませんでした。エラー: '{0}'"
+}

--- a/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/ko-KR/resources.resjson
@@ -1,0 +1,5 @@
+{
+  "loc.messages.UnsupportedTLSError": "머신에서 TLS 1.2 프로토콜 이상을 사용 중인지 확인하세요. 머신에서 TLS를 사용하도록 설정하는 방법에 대해 자세히 알아보려면 https://aka.ms/enableTlsv2를 참조하세요.",
+  "loc.messages.TLS12AddedInSession": "세션에서 TLS 1.2가 추가되었습니다.",
+  "loc.messages.UnableToAddTls12InSession": "현재 세션에서 TLS 1.2를 추가하지 못했습니다. 오류: '{0}'"
+}

--- a/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/ru-RU/resources.resjson
@@ -1,0 +1,5 @@
+{
+  "loc.messages.UnsupportedTLSError": "Компьютер должен использовать протокол TLS 1.2 или более поздней версии. Дополнительные сведения о том, как включить TLS на вашем компьютере: https://aka.ms/enableTlsv2.",
+  "loc.messages.TLS12AddedInSession": "TLS 1.2 добавлен в сеансе.",
+  "loc.messages.UnableToAddTls12InSession": "Не удалось добавить TLS 1.2 в текущем сеансе. Ошибка: \"{0}\"."
+}

--- a/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/zh-CN/resources.resjson
@@ -1,0 +1,5 @@
+{
+  "loc.messages.UnsupportedTLSError": "请确保计算机使用的是 TLS 1.2 协议或更高版本。请访问 https://aka.ms/enableTlsv2 获取有关如何在计算机中启用 TLS 的详细信息。",
+  "loc.messages.TLS12AddedInSession": "会话中已添加 TLS 1.2。",
+  "loc.messages.UnableToAddTls12InSession": "未能在当前会话中添加 TLS 1.2。错误: {0}"
+}

--- a/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/Strings/resources.resjson/zh-TW/resources.resjson
@@ -1,0 +1,5 @@
+{
+  "loc.messages.UnsupportedTLSError": "請確定電腦目前使用 TLS 1.2 通訊協定或更高的版本。請查看 https://aka.ms/enableTlsv2，以取得如何於您的電腦上啟用 TLS 的詳細資訊。",
+  "loc.messages.TLS12AddedInSession": "已在工作階段中新增 TLS 1.2。",
+  "loc.messages.UnableToAddTls12InSession": "無法在目前的工作階段中新增 TLS 1.2。錯誤: '{0}'"
+}

--- a/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/TlsHelper.psm1
+++ b/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/TlsHelper.psm1
@@ -1,0 +1,61 @@
+Import-VstsLocStrings -LiteralPath $PSScriptRoot/module.json
+
+function Add-Tls12InSession {
+    [CmdletBinding()]
+    param()
+
+    try {
+        if ([Net.ServicePointManager]::SecurityProtocol.ToString().Split(',').Trim() -notcontains 'Tls12') {
+            $securityProtocol=@()
+            $securityProtocol+=[Net.ServicePointManager]::SecurityProtocol
+            $securityProtocol+=[Net.SecurityProtocolType]3072
+            [Net.ServicePointManager]::SecurityProtocol=$securityProtocol
+            
+            Write-Host (Get-VstsLocString -Key TLS12AddedInSession)
+        }
+        else {
+            Write-Verbose 'TLS 1.2 already present in session.'
+        }
+    }
+    catch {
+        Write-Host (Get-VstsLocString -Key "UnableToAddTls12InSession" -ArgumentList $($_.Exception.Message))
+    }
+}
+
+function Assert-TlsError {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [AllowNull()]
+        $exception
+    )
+
+    if ($exception -eq $null)
+    {
+        return
+    }
+
+    $hasWebException = $false
+    $hasIOException = $false
+    $innerException = $exception
+    while ($innerException -ne $null)
+    {
+        if ($innerException.GetType() -eq [System.Net.WebException])
+        {
+            $hasWebException = $true
+        }
+        elseif ($innerException.GetType() -eq [System.IO.IOException])
+        {
+            $hasIOException = $true
+        }
+        $innerException = $innerException.InnerException
+    }
+
+    if (($hasWebException -eq $true) -and ($hasIOException -eq $true))
+    {
+        Write-VstsTaskError -Message (Get-VstsLocString -Key UnsupportedTLSError)
+    }
+}
+
+Export-ModuleMember -Function Add-Tls12InSession
+Export-ModuleMember -Function Assert-TlsError

--- a/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/module.json
+++ b/tf-vc-shared/v2/ps_modules/VstsTfvcShared/TlsHelper/module.json
@@ -1,0 +1,7 @@
+{
+    "messages": {
+        "UnsupportedTLSError": "Make sure the machine is using TLS 1.2 protocol or higher. Check https://aka.ms/enableTlsv2 for more information on how to enable TLS in your machine.",
+        "TLS12AddedInSession": "Added TLS 1.2 in session.",
+        "UnableToAddTls12InSession" : "Failed to add TLS 1.2 in current session. Error: '{0}'"
+    }
+}

--- a/tf-vc-shared/v2/ps_modules/VstsTfvcShared/VstsTfvcShared.psm1
+++ b/tf-vc-shared/v2/ps_modules/VstsTfvcShared/VstsTfvcShared.psm1
@@ -13,6 +13,9 @@ function Write-Message{
     }
 }
 
+Import-Module $PSScriptRoot/TlsHelper
+Add-Tls12InSession
+
 function Find-VisualStudio {
     $ErrorActionPreference = 'Stop'
     


### PR DESCRIPTION
While this should really have been a concern of the PowerShell Execution Handler or the Azure-Pipelines-Task-Lib, it seems that a fix is needed until this is ported to where it belongs.

Closes #91.

Should also be fixed by configuring secure channel for .NET correctly on the server. But this seems to be what the official tasks are doing whether I like it or not.